### PR TITLE
some fixes regarding issue #4379 and other minor changes

### DIFF
--- a/src/extractor/luscious_downloader.py
+++ b/src/extractor/luscious_downloader.py
@@ -1,5 +1,6 @@
 #coding:utf8
 import downloader
+import requests
 from utils import Soup, Downloader, LazyUrl, urljoin, try_n, get_outdir, clean_title
 import ree as re
 import os
@@ -49,7 +50,7 @@ class Downloader_luscious(Downloader):
         url = fix_url(self.url)
         for try_ in range(8):
             try:
-                html = downloader.read_html(url)
+                html = requests.get(url).text
                 break
             except Exception as e:
                 print(e)

--- a/src/extractor/tumblr_downloader.py
+++ b/src/extractor/tumblr_downloader.py
@@ -113,7 +113,7 @@ class TumblrAPI(object):
             if self.cw and not self.cw.alive:
                 break
             data = self.call(path, qs, default_qs=default_qs)
-            for post in data['posts']:
+            for post in (post for post in data['posts'] if post['object_type'] != 'backfill_ad'):
                 id_ = post['id']
                 if id_ in ids:
                     self.print_('duplicate: {}'.format(id_))

--- a/src/extractor/wayback_machine_downloader.py
+++ b/src/extractor/wayback_machine_downloader.py
@@ -14,6 +14,7 @@ from ratelimit import limits, sleep_and_retry
 class Downloader_wayback_machine(Downloader):
     type = 'waybackmachine'
     URLS = ['archive.org', 'web.archive.org']
+    icon = 'https://archive.org/offshoot_assets/favicon.ico'
     display_name = 'Wayback Machine'
 
     def read(self):
@@ -62,7 +63,7 @@ class Filter(object):
         self.title = self.__get_title()
 
     def __get_mode(self):
-        for mode in [mode for mode, domain in enumerate(self.domains, start=1) if domain in self.url]:
+        for mode in (mode for mode, domain in enumerate(self.domains, start=1) if domain in self.url):
             return mode
         return 0
 
@@ -72,7 +73,7 @@ class Filter(object):
             return clean_title(os.path.basename(self.base_url), n=-len(tail)) + tail
 
         def twitter():
-            return '@' + re.findall('twitter.[^/]+/([^/?]+)', self.url)[0]
+            return '@' + re.findall('twitter.[^/]+/([^/*?]+)', self.url)[0]
 
         return [
             default,


### PR DESCRIPTION
tumblr_downloader: 
Removed backfill ads from post queries.
Doesn't seem to be any option to filter posts beforehand using Tumblr's API.

luscious_downloader: 
`downloader.read_html()` failed to return html correctly for the following url:
```
https://www.luscious.net/albums/lu-s-cat-lingerie-collection_275528/
```
Seems to work well now using `requests.get()`.


wayback_machine_downloader:
Added an icon and a small optimization.