### PR TITLE
핀터레스트 보드 다운로드가 되지 않는 버그 수정(웹 사이트 변경)

### DIFF
--- a/src/extractor/pinter_downloader.py
+++ b/src/extractor/pinter_downloader.py
@@ -147,8 +147,9 @@ class PinterestAPI:
     def _call(self, resource, options):
         url = f'{BASE_URL}/resource/{resource}Resource/get/'
         params = {'data': json.dumps({'options': options}), 'source_url': ''}
+        headers = {'X-Pinterest-PWS-Handler': 'www/[username]/[slug].js'}
         #print(f'_call: {url}, {params}')
-        r = self.session.get(url, params=params)
+        r = self.session.get(url, params=params, headers=headers)
         s = r.text
         status_code = r.status_code
         try:


### PR DESCRIPTION
이슈 https://github.com/KurtBestor/Hitomi-Downloader/issues/7690, https://github.com/KurtBestor/Hitomi-Downloader/issues/7747 해결 패치입니다.

웹 사이트 변경으로 인해 `GET /resource/BoardFeedResource/get/` 요청을 날리면 `Invalid Resource Request`를 반환하는 문제가 있었는데, https://github.com/mikf/gallery-dl/issues/6513#issuecomment-2493375798 댓글에서 언급한 대로 `'X-Pinterest-PWS-Handler': 'www/[username]/[slug].js'` 헤더를 추가해 주니 문제가 해결되었습니다.